### PR TITLE
Add option to create response with headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "aws-lambda-response-builder",
-	"version": "1.0.4",
+	"version": "1.0.5",
 	"description": "A simple library to create AWS Lambda responses",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/src/api-gateway/apiGatewayResponseBuilder.ts
+++ b/src/api-gateway/apiGatewayResponseBuilder.ts
@@ -30,6 +30,15 @@ export class ApiGatewayResponseBuilder {
 	  return this
 	}
 
+	public withHeaders(headers: object) {
+	  this.headers = {
+	    ...this.headers,
+	    ...headers
+	  }
+
+	  return this
+	}
+
 	public build = (): APIGatewayProxyResult => {
 	  return {
 	    statusCode: this.statusCode,

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,23 +7,31 @@ export * from './api-gateway/apiGatewayResponseBuilder'
 const buildApiGatewayResponse = (
   statusCode: number,
   body: object = {},
-  cors: boolean = true
+  cors: boolean = true,
+  headers?: object
 ): APIGatewayProxyResult => {
   const builder = new ApiGatewayResponseBuilder(statusCode, body)
+
   if (cors) {
     builder.withCors()
   }
+
+  if (headers) {
+    builder.withHeaders(headers)
+  }
+
   return builder.build()
 }
 
 export const buildApiGatewayOkResponse = (
   body?: object,
-  cors?: boolean
+  cors?: boolean,
+  headers?: object
 ): APIGatewayProxyResult => {
-  return buildApiGatewayResponse(HttpStatus.OK, body, cors)
+  return buildApiGatewayResponse(HttpStatus.OK, body, cors, headers)
 }
 
-export const buildApiGatewayCreatedresponse = (
+export const buildApiGatewayCreatedResponse = (
   body?: object,
   cors?: boolean
 ): APIGatewayProxyResult => {

--- a/test/api-gateway/apiGatewayResponseBuilder.test.ts
+++ b/test/api-gateway/apiGatewayResponseBuilder.test.ts
@@ -61,7 +61,7 @@ describe('API Gateway Response Builder', () => {
     )
   })
 
-  it('creates an API Gateway response with custom headers', () => {
+  it('creates an API Gateway response with custom header', () => {
     const statusCode = casual.integer(RANDOM_START, RANDOM_END)
     const randomHeaderKey = casual.word
     const randomHeaderValue = casual.word
@@ -77,6 +77,28 @@ describe('API Gateway Response Builder', () => {
 
     expect(response.headers).not.toBeNull()
     expect(response.headers![randomHeaderKey]).toEqual(randomHeaderValue)
+  })
+
+  it('creates an API Gateway response with custom header', () => {
+    const statusCode = casual.integer(RANDOM_START, RANDOM_END)
+
+    const builder = new ApiGatewayResponseBuilder(statusCode, undefined)
+
+    const response = builder
+      .withCors()
+      .withHeaders({
+        'Content-disposition': 'attachment; filename="research-data.ifsttar.fr.png"',
+        'Content-Type': 'image/png; name="research-data.ifsttar.fr.png"'
+      })
+      .build()
+
+    expect(response.statusCode).toEqual(statusCode)
+
+    expect(response.headers).not.toBeNull()
+    expect(response.headers!['Access-Control-Allow-Origin']).toEqual('*')
+    expect(response.headers!['Access-Control-Allow-Credentials']).toEqual(true)
+    expect(response.headers!['Content-disposition']).toEqual('attachment; filename="research-data.ifsttar.fr.png"')
+    expect(response.headers!['Content-Type']).toEqual('image/png; name="research-data.ifsttar.fr.png"')
   })
 
   it('creates an API Gateway response with status code, body, CORS, and custom header', () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -2,7 +2,7 @@ import casual from 'casual'
 import {
   buildApiGatewayAcceptedResponse,
   buildApiGatewayBadRequest,
-  buildApiGatewayCreatedresponse,
+  buildApiGatewayCreatedResponse,
   buildApiGatewayCustomStatusCode,
   buildApiGatewayNotFound,
   buildApiGatewayOkResponse,
@@ -28,7 +28,7 @@ const testResponseTypes = [
   },
   {
     type: 'Created',
-    fn: buildApiGatewayCreatedresponse,
+    fn: buildApiGatewayCreatedResponse,
     expectedStatusCode: HttpStatus.CREATED
   },
   {


### PR DESCRIPTION
Allow adding headers when building an OK response.

This will help building responses where the content-type is different to 'application/json'